### PR TITLE
Depend on `:elixir_uuid` instead of `:uuid`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Alchemy.Mixfile do
 
   defp deps do
     [
-      {:uuid, "~> 1.1"},
+      {:elixir_uuid, "~> 1.2"},
       {:ex_doc, "~> 0.20", only: :dev},
       {:earmark, "~> 1.2", only: :dev}
     ]


### PR DESCRIPTION
```
* uuid (Hex package)
  could not find an app file at "_build/dev/lib/uuid/ebin/uuid.app". This may happen if the dependency was not yet compiled or the dependency indeed has no app file (then you can pass app: false as option)
** (Mix) Can't continue due to errors on dependencies
```

https://github.com/zyro/elixir-uuid/issues/33