### PR TITLE
Remove uuid dep and bump Elixir/OTP versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      # specify the version here
-      - image: circleci/elixir:1.7
+      - image: cimg/elixir:1.14.3
 
     working_directory: ~/repo
     steps:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.10.2
-erlang 22.2.8
+elixir 1.14.3-otp-25
+erlang 25.2.3

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ defmodule Publisher do
       candidate: observation_payload(Enum.at(result.candidates, 0))
     }
 
-    :ets.insert(:alchemy, {result.name, result.uuid, payload})
+    :ets.insert(:alchemy, {result.name, payload})
   end
 
   # If this observation raised an error then store the error

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,4 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 config :alchemy,
   publish_module: Alchemy.Publishers.NullPublisher

--- a/lib/alchemy/experiment.ex
+++ b/lib/alchemy/experiment.ex
@@ -1,7 +1,6 @@
 defmodule Alchemy.Experiment do
   defstruct [
     name: "",
-    uuid: nil,
     behaviors: [],
     result: nil,
     publisher: nil,
@@ -20,7 +19,7 @@ defmodule Alchemy.Experiment do
   Generates a new experiment. Alias for `Experiment.new/1`
   """
   def experiment(title) do
-    %Experiment{name: title, uuid: uuid()}
+    %Experiment{name: title}
     |> comparator(fn(a, b) -> a == b end)
     |> clean(fn value -> value end)
   end
@@ -147,10 +146,6 @@ defmodule Alchemy.Experiment do
       value ->
         value
     end
-  end
-
-  defp uuid do
-    UUID.uuid1()
   end
 end
 

--- a/lib/alchemy/result.ex
+++ b/lib/alchemy/result.ex
@@ -3,7 +3,6 @@ defmodule Alchemy.Result do
     name: nil,
     control: nil,
     candidates: [],
-    uuid: nil,
     mismatched: [],
     ignored: [],
   ]
@@ -23,7 +22,6 @@ defmodule Alchemy.Result do
 
     %Result{
       name: experiment.name,
-      uuid: experiment.uuid,
       control: control,
       candidates: candidates,
       mismatched: mismatched,

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Alchemy.Mixfile do
     [
       app: :alchemy,
       description: "Perform experiments in production",
-      version: "0.3.1",
+      version: "1.0.0-dev",
       elixir: "~> 1.7",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
@@ -21,7 +21,6 @@ defmodule Alchemy.Mixfile do
 
   defp deps do
     [
-      {:uuid, "~> 1.1"},
       {:ex_doc, "~> 0.20", only: :dev},
       {:earmark, "~> 1.2", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -6,5 +6,4 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.16.0", "f8c570a0d33f8039513fbccaf7108c5d750f47d8defd44088371191b76492b0b", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "28b2cbdc13960a46ae9a8858c4bebdec3c9a6d7b4b9e7f4ed1502f8159f338e7"},
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
-  "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm", "c790593b4c3b601f5dc2378baae7efaf5b3d73c4c6456ba85759905be792f2ac"},
 }

--- a/test/alchemy/experiment_test.exs
+++ b/test/alchemy/experiment_test.exs
@@ -10,10 +10,6 @@ defmodule Alchemy.ExperimentTest do
     assert experiment("test").name == "test"
   end
 
-  test "experiment/1 generates a unique identifier" do
-    assert experiment("test").uuid
-  end
-
   test "experiment/1 generates a default comparator" do
     assert experiment("test").compare
   end
@@ -23,7 +19,7 @@ defmodule Alchemy.ExperimentTest do
       experiment("test")
       |> comparator(fn(a, b) -> a.value == b.value end)
 
-    assert exp.compare.(%{uuid: 1, value: 1337}, %{uuid: 2, value: 1337})
+    assert exp.compare.(%{something_ignored: 1, value: 1337}, %{something_ignored: 2, value: 1337})
   end
 
   test "control/2 assigns the control" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start()
+ExUnit.start(capture_log: true)


### PR DESCRIPTION
I was looking into solving the problem described in #47 which ultimately arrives [here](https://github.com/zyro/elixir-uuid/pull/28) with an explanation of why the library was renamed, and there are a bunch of PRs to various projects to update it to use the new name.

I looked into why Alchemy even needs this dependency at all, and it seems like it actually doesn't. It is just generating a UUID for each experiment and returning it along with each of the results. The README talks about using that UUID to publish the results somewhere, but it would be just as easy to generate a random one right there in the publisher if that's what you want, so I'm proposing that we remove it from Alchemy.

I'm also proposing that we bump the version to 1.0.0 since this is technically a breaking change (it removes something from the API that was there before), and the codebase has been stable and working well for years at this point (other than this recent dependency conflict as soon as one of your other dependencies tries to use `elixir_uuid`).